### PR TITLE
Fix the FSharp.Core reference

### DIFF
--- a/src/Grinder.Common/Grinder.Common.fsproj
+++ b/src/Grinder.Common/Grinder.Common.fsproj
@@ -2,6 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
+        <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     </PropertyGroup>
 
     <ItemGroup>
@@ -9,8 +10,8 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="TaskBuilder.fs" Version="2.1.0" />
-      <PackageReference Include="FSharp.Core" Version="4.6.2" />
+        <PackageReference Include="FSharp.Core" Version="4.6.2" />
+        <PackageReference Include="TaskBuilder.fs" Version="2.1.0" />
     </ItemGroup>
 
 </Project>

--- a/src/Grinder.ExportTool/Grinder.ExportTool.fsproj
+++ b/src/Grinder.ExportTool/Grinder.ExportTool.fsproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.2</TargetFramework>
+    <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
   </PropertyGroup>
 
   <ItemGroup>
@@ -11,6 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="FSharp.Control.AsyncSeq" Version="2.0.21" />
+    <PackageReference Include="FSharp.Core" Version="4.6.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="TDLib" Version="1.3.0" />
     <PackageReference Include="tdlib.native" Version="1.3.0" />

--- a/src/Grinder/Grinder.fsproj
+++ b/src/Grinder/Grinder.fsproj
@@ -5,10 +5,12 @@
         <TargetFramework>netcoreapp2.2</TargetFramework>
         <ServerGarbageCollection>false</ServerGarbageCollection>
         <TieredCompilation>true</TieredCompilation>
+        <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="FParsec" Version="1.0.3" />
+        <PackageReference Include="FSharp.Core" Version="4.6.2" />
         <PackageReference Include="FSharp.UMX" Version="1.0.0-preview-001" />
         <PackageReference Include="Funogram" Version="1.3.1" />
         <PackageReference Include="HttpToSocks5Proxy" Version="1.1.3" />

--- a/tests/Grinder.Tests/Grinder.Tests.fsproj
+++ b/tests/Grinder.Tests/Grinder.Tests.fsproj
@@ -1,9 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <GenerateProgramFile>false</GenerateProgramFile>
     <IsPackable>false</IsPackable>
+    <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,6 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="FSharp.Core" Version="4.6.2" />
     <PackageReference Include="Foq" Version="1.8.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
     <PackageReference Include="xunit" Version="2.4.1" />


### PR DESCRIPTION
Funogram uses FSharp.Core 4.6.2 while by default our target SDK (2.2.100) enforces usage of 4.5.2. In this PR, I manually set up the version of FSharp.Core for us to use.